### PR TITLE
Fixed a small typo in example launch file

### DIFF
--- a/z1_examples/launch/waypoint_test.launch.py
+++ b/z1_examples/launch/waypoint_test.launch.py
@@ -38,7 +38,7 @@ def launch_setup(context, *args, **kwargs):
             FindPackageShare("z1_bringup"), "/launch/z1.launch.py"
         ], ),
         launch_arguments={
-            "sim_ingition": sim_ignition,
+            "sim_ignition": sim_ignition,
             "starting_controller": "joint_trajectory_controller",
         }.items(),
     )


### PR DESCRIPTION
`sim_ignition` was spelled as `sim_ingition` in the launch file for z1_examples.